### PR TITLE
fix i3ipc v2 compatibility, improve multi-mon support

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,22 +1,65 @@
 Configuration
 =============
 
-The only configuration option available is for specifing if you want context-switching integration with any of the supported window managers below. With this integration, as soon as you switch context, rofi-tmux will switch to the appropriate workspace where tmux is running. First, you have to create the json configuration file ``~/.rft`` and then specify which window manager you're running:
+All configuration is optional, and is to be written in a json file at ``~/.rft``.
+
+- ``wm``
+
+  Defines which window manager we want to integrate with for smoother context-switching.
+  With this integration, as soon as you switch context, rofi-tmux will
+  automatically focus window where tmux is running.
+  Currently the only supported window manager is ``i3``, which is also the only possible value.
+  
+  .. note::
+  
+      Feel free to send pull requests for other window managers that support multiple workspaces.
+
+- ``tmux_title_rgx``
+
+  Only applicable when ``wm`` config is set.
+  This is the regular expression used by window-manager integration logic to locate the
+  window housing specific tmux session. Generally you'd like this (roughly) to match
+  your tmux configuration. The pattern also supports two optional
+  placeholders that will be automatically expanded:
+ 
+  + ``{session}`` will be expanded into tmux session name
+  + ``{window}`` will be expanded into tmux window name
+
+  Eg if you have ``set -g set-titles-string "#S / #W / #T"`` in your .tmux.conf, you
+  might want to set to this value:
+
+  .. code:: json
+  
+      {
+          "tmux_title_rgx": "^{session} / {window} / "
+      }
+
+
+- ``ignored_sessions``
+
+  Optional list of tmux session names that should be ignored when building the
+  selection menu.
+  Eg:
+
+  .. code:: json
+  
+      {
+          "ignored_sessions": ["session-name", "other-session-name"]
+      }
+
 
 .. note::
 
     If you want to change the algorithm rofi uses, you should change it on rofi rc configuration file itself, "~/.config/rofi/config", for example to uses the fuzzy macher you should set rofi.matching attribute as "fuzzy".
 
-i3wm
-----
+config example using i3wm
+-------------------------
 
 .. code:: json
 
     {
-        "wm": "i3"
+        "wm": "i3",
+        "tmux_title_rgx": "^tmux-{session}-{window}",
+        "ignored_sessions": ["session-name-to-ignore"]
     }
-
-.. note::
-
-    Feel free to send pull requests for other window managers that support multiple workspaces.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,3 +6,9 @@ Simply pip3 install:
 .. code:: shell
 
     pip3 install rofi-tmux --user -U
+
+Dependencies
+============
+
+Optional (but recommended) dependency is ``xprop``, which will be used to query
+tmux window visibility.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -4,7 +4,7 @@ Usage
 Two things you have to keep in mind when using rft:
 
 1. rft doesn't launch a terminal automatically for you, so, if you don't have a tmux session attached yet you're supposed to run rft in the terminal (``rft ss`` or ``rft lp``).
-2. rft caches the last tmux session/window you have switched from, so it automatically pre select it in the rofi prompt, except if you are in a different workspace, where rft assumes that you probably want to switch over to the same session/window you where before.
+2. rft caches the last tmux session/window you have switched from, so it automatically pre-selects it in the rofi prompt, except if you are in a different workspace, where rft assumes that you probably want to switch over to the same session/window you were before/that is currently opened.
 
 
 I recommend that you have shortcuts with control modifiers for rft, so if you always have a tmux session running, it's going to be really fast to find this session and switch to it. For example, I use these key bindings on i3wm for launching rft:
@@ -22,7 +22,8 @@ I recommend that you have shortcuts with control modifiers for rft, so if you al
 
     If you have pip3 installed with the --user flag the executable will be in ~/$HOME/.local/bin/rft.
 
-The first three are the ones that I use the most. They're for loading a tmuxinator project, switch to a session and switch to a window globally. So, I set some keys that are near my home row. If you want to check all rft actions available:
+The first three are the ones that I use the most. They're for loading a tmuxinator project (`lp`), switching to a session (`ss`) and switching to a window globally (`sw`).
+So, I set some keys that are near my home row. If you want to check all rft actions available:
 
 .. code:: shell
 

--- a/rft/i3wm.py
+++ b/rft/i3wm.py
@@ -4,69 +4,112 @@
 from .window_manager import WindowManager
 import i3ipc
 import logging
+from re import escape
+from subprocess import check_output
+from collections import defaultdict
 
 
 class i3WM(WindowManager):
     """Abstraction to handle i3wm"""
 
-    def __init__(self) -> None:
+    def __init__(self, conf, logger_lvl = None) -> None:
+
         """Constructor
 
         """
         self._i3 = i3ipc.Connection()
-        self._cur_wks = self._get_cur_workspace()
+        self._cur_ws_id = self._get_cur_workspace()
+        self._conf = conf
         self.logger = logging.getLogger(__name__)
+        if logger_lvl != None:
+            self.logger.setLevel(logger_lvl)
+
         super(i3WM, self).__init__()
 
-    def switch_tmux_workspace(self, session_name) -> None:
-        """Switches to the workspace where tmux session_name is running
+    def focus_tmux_window(self, session) -> None:
+        """Focuses window where given tmux session is running in
 
-        :session_name: tmux session name str
-
-        """
-        self.logger.debug('cur_i3_wks:{}'.format(self._cur_wks))
-        self.logger.debug('i3 switching to workspace: {}'.format(session_name))
-        wkps = self._find_tmux_workspace(session_name)
-        if wkps:
-            wkps.command('workspace {}'.format(wkps.name))
-
-    def is_tmux_not_in_cur_workspace(self, session_name) -> i3ipc.Con:
-        """Verifies if tmux is not in the current i3 workspace
-
-        :session_name: tmux sesion name to verify
+        :session: tmux session whose window to focus
 
         """
-        workspace = self._find_tmux_workspace(session_name)
-        if workspace:
-            if not workspace.name == self._cur_wks:
-                return workspace
+        if not session:
+            return None
+
+        tmux_win = self._find_tmux_window(session)
+        if tmux_win:
+            self.logger.debug('i3 focusing window running tmux session [{}]'.format(session.name))
+            tmux_win.command('focus')
+
+    def is_tmux_win_visible(self, session) -> bool:
+        """Verifies if window where given tmux session is running in is visible
+
+        :session: tmux session whose visibility to check
+
+        """
+        if not session:
+            return False
+
+        tmux_win = self._find_tmux_window(session)
+        if tmux_win:
+            return self._is_win_visible(tmux_win)
         return False
 
-    def _get_cur_workspace(self) -> str:
-        """Finds current workspace
+    def _is_win_visible(self, i3_win) -> bool:
+        """Verify if given i3ipc.Con housing our tmux session is visible on our
+        screen(s).
+
+        :i3_win: i3ipc.Con housing tmux session whose visibility to test.
 
         """
-        workspaces = self._i3.get_workspaces()
-        for workspace in workspaces:
-            if workspace.get('visible'):
-                return workspace.get('name')
+        try:
+            xprop = check_output(['xprop', '-id', str(i3_win.window)]).decode()
+            return '_NET_WM_STATE_HIDDEN' not in xprop
+        except FileNotFoundError:
+            # if xprop not found, fall back to just checking if tmux win is on our current worksapce:
+            self.logger.debug('xprop utility is not found - please install it.')
+            self.logger.debug('will decide visibility simply by checking if tmux is on our current workspace')
+            return self._is_tmux_win_on_current_ws(i3_win)
 
-    def _find_tmux_workspace(self, session_name) -> i3ipc.Con:
-        """Finds which workspace tmux is running
+    def _is_tmux_win_on_current_ws(self, i3_win) -> bool:
+        """Verifies if tmux is in the current (ie focused) i3 workspace
 
-        :session_name: tmux sesion name to find
+        :i3_win: i3ipc.Con housing our tmux session
 
         """
-        tree = self._i3.get_tree()
-        descendents = tree.descendents()
-        workspaces = [
-            descendent for descendent in descendents
-            if descendent.type == 'workspace'
-        ]
-        self.logger.debug('finding i3 tmux session {}'.format(session_name))
-        for w in workspaces:
-            cons = w.find_named(session_name)
-            if cons:
-                self.logger.debug('tmux session {} is in workspace {}'.format(
-                    session_name, w.name))
-                return w
+        workspace = i3_win.workspace()
+        return workspace and workspace.id == self._cur_ws_id
+
+    def _get_cur_workspace(self) -> int:
+        """Finds & returns the id of current (ie focused) workspace.
+
+        """
+        return self._i3.get_tree().find_focused().workspace().id
+
+    def _find_tmux_window(self, session) -> i3ipc.Con:
+        """Finds and returns i3 Container instance housing tmux window that's
+        currently attached to provided session.
+
+        :session: tmux session whose window to find.
+
+        """
+        session_name = escape(session.name)
+        window_name = escape(session.attached_window.name)
+        rgx = self._conf['tmux_title_rgx'].format_map(defaultdict(str,
+                session = session_name,
+                window = window_name
+        ))
+
+        tmux_win = self._i3.get_tree().find_named(rgx)
+        # just in case filter by container type - we want regular & floating window containers:
+        tmux_win = list(filter(lambda c: c.type.endswith('con'), tmux_win))
+
+        if tmux_win:
+            if len(tmux_win) > 1:
+                self.logger.debug('found [{}] windows using regex [{}], but expected 1'
+                        .format(len(tmux_win), rgx))
+                self.logger.debug('you should likely make conf.tmux_title_rgx more limiting')
+            return tmux_win[0]
+
+        self.logger.debug('found no windows using regex [{}]'.format(rgx))
+        return None
+

--- a/rft/rft.py
+++ b/rft/rft.py
@@ -19,44 +19,47 @@ class RFT(object):
         self._rofi = rofi.Rofi()
         self._libts = libtmux.Server()
         self._sessions = None
-        self._wm = None
         self._cur_tmux_s = None
-        self._cur_i3_s = None
         self.logger = logging.getLogger(__name__)
         if debug:
             self.logger.setLevel(logging.DEBUG)
-        self._cache_f = os.path.join(os.environ.get('HOME'), '.rft.cache')
-        self._cache = {}
-        self._config_f = os.path.join(os.environ.get('HOME'), '.rft')
 
+        homedir = os.environ.get('HOME')
+        self._cache_f = os.path.join(homedir, '.rft.cache')
+        self._cache = self._load_cache()
+        self._config = self._load_config(os.path.join(homedir, '.rft'))
         self._register_cur_sessions()
-        self._load_cache()
-        self._load_config()
+        if self._config.get('wm') == 'i3':
+            self._wm = i3WM(self._config, logger_lvl = self.logger.getEffectiveLevel())
+        else:
+            self._wm = None
 
-    def _load_config(self) -> None:
+    def _load_config(self, conf_file_loc) -> None:
         """Load json config file ~/.rft.
 
         Currently supported window managers: 'i3'
 
         """
-        config = {'wm': ''}
-        try:
-            with open(self._config_f, 'r') as f:
-                config = json.load(f)
-                if config.get('wm') == 'i3':
-                    self._wm = i3WM()
-        except FileNotFoundError as e:
-            pass
-        self.logger.debug('loaded config: {}'.format(config))
+        conf = {
+                'wm': None,
+                'tmux_title_rgx': '{session}',
+                'ignored_sessions': []
+        }
+        conf.update(_read_dict_from_file(conf_file_loc))
+        self.logger.debug('effective config: {}'.format(conf))
+        return conf
+
 
     def _load_cache(self) -> None:
         """Load last tmux sessions and window cache."""
-        try:
-            with open(self._cache_f, 'r') as f:
-                self._cache = json.load(f)
-        except FileNotFoundError as e:
-            self._cache = {'last_tmux_s': None, 'last_tmux_w': None}
-        self.logger.debug('loaded cache: {}'.format(self._cache))
+
+        cache = {
+                'last_tmux_s': None,
+                'last_tmux_w': None
+        }
+        cache.update(_read_dict_from_file(self._cache_f))
+        self.logger.debug('loaded cache: {}'.format(cache))
+        return cache
 
     def _write_cache(self) -> None:
         """Write cache."""
@@ -73,36 +76,39 @@ class RFT(object):
         except IOError as e:
             raise e
 
+    def _get_sessions_filtered(self) -> list:
+        """Return list of tmux sessions, sans ones explicitly blacklisted
+        by self._config.ignored_sessions"""
+        return [s for s in self._libts.list_sessions() if s.name not in self._config['ignored_sessions']]
+
     def _register_cur_sessions(self) -> None:
-        """Register the current tmux sessions."""
+        """Register the current tmux sessions _sessions, and
+        store current active session in _cur_tmux_s"""
         try:
-            self._sessions = self._libts.list_sessions()
+            self._sessions = self._get_sessions_filtered()
             self.logger.debug('_sessions: {}'.format(self._sessions))
         except libtmux.exc.LibTmuxException as e:
             # if there are no sessions running load_project takes place
             self.load_tmuxinator()
         self._cur_tmux_s = self._get_cur_session()
-        self.logger.debug('_cur_tmux_s: {}'.format(self._cur_tmux_s))
+        self.logger.debug('_cur_tmux_s: {}'.format(self._cur_tmux_s.name if self._cur_tmux_s else self._cur_tmux_s))
 
-    def _get_cur_session(self) -> str:
-        """Get current tmux session name."""
-        out, err = subprocess.Popen(
-            "tmux list-panes -F '#{session_name}'",
-            shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE).communicate()
-        for line in out.splitlines():
-            return line.decode('utf-8').split()[-1]
+    def _get_cur_session(self) -> libtmux.session.Session:
+        """Return reference to our current tmux session."""
+        for s in self._sessions:
+            if str(s.attached) != '0':
+                return s
+        return None
 
-    def _get_cur_window(self) -> str:
+    def _get_cur_tmux_win(self) -> str:
         """Get current tmux window."""
-        if self._cur_tmux_s:
-            for w in self._libts._list_windows():
-                if w.get('session_name') == self._cur_tmux_s:
-                    if w.get('window_active') == '1':
-                        return "{}:{}:{}".format(
-                            w.get('session_name'), w.get('window_index'),
-                            w.get('window_name'))
+        if not self._cur_tmux_s:
+            return None
+        else:
+            return '{}:{}:{}'.format(
+                self._cur_tmux_s.name,
+                self._cur_tmux_s.attached_window.index,
+                self._cur_tmux_s.attached_window.name)
 
     def _get_tmuxinator_projects(self) -> list:
         """Get tmuxinator projects name."""
@@ -129,6 +135,7 @@ class RFT(object):
             for s in self._sessions:
                 if s.name == session_name:
                     return s
+        return None
 
     def _rofi_tmuxinator(self, rofi_msg, rofi_err) -> None:
         """Launch rofi for loading a tmuxinator project.
@@ -147,21 +154,20 @@ class RFT(object):
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE).communicate()
                 # update sessions.
-                self._sessions = self._libts.list_sessions()
+                self._sessions = self._get_sessions_filtered()
                 session = self._get_session_by_name(projects[res])
-                workspace = None
+                if not session:
+                    return
                 if self._wm:
-                    workspace = self._wm.is_tmux_not_in_cur_workspace(
-                        self._cur_tmux_s)
-                    if workspace:
-                        self._wm.switch_tmux_workspace(session.name)
+                    self._wm.focus_tmux_window(self._cur_tmux_s)
                 try:
                     session.attach_session()
                 except libtmux.exc.LibTmuxException as e:
                     # there are no attached clients just switch instead.
                     session.switch_client()
-                self._cache['last_tmux_s'] = self._cur_tmux_s
-                self._write_cache()
+                if self._cur_tmux_s:
+                    self._cache['last_tmux_s'] = self._cur_tmux_s.name
+                    self._write_cache()
         else:
             self._rofi.error(rofi_err)
 
@@ -180,33 +186,33 @@ class RFT(object):
         """
         if self._sessions:
             sessions_list = [s.name for s in self._sessions]
-            tmux_wkps = None
+            is_tmux_win_visible = False
             if self._wm:
-                tmux_wkps = self._wm.is_tmux_not_in_cur_workspace(
-                    self._cur_tmux_s)
+                self.logger.debug('resolving is_tmux_win_visible...')
+                is_tmux_win_visible = self._wm.is_tmux_win_visible(self._cur_tmux_s)
+                self.logger.debug('is_tmux_win_visible: {}'.format(is_tmux_win_visible))
             try:
-                # select cur session if it's not int the same workspace
-                if tmux_wkps:
-                    sel = sessions_list.index(self._cur_tmux_s)
-                # otherwise selected the last session
-                else:
+                if is_tmux_win_visible:
                     sel = sessions_list.index(self._cache.get('last_tmux_s'))
+                elif self._cur_tmux_s:
+                    sel = sessions_list.index(self._cur_tmux_s.name)
+                else:
+                    sel = 0
             except ValueError as e:
                 sel = 0
             res, key = self._rofi.select(rofi_msg, sessions_list, select=sel)
             if key == 0:
                 session = self._sessions[res]
                 if action == 'switch':
-                    # if cur tmux session is not in the current workspace
-                    if tmux_wkps:
-                        self._wm.switch_tmux_workspace(session.name)
+                    if self._wm:
+                        self._wm.focus_tmux_window(self._cur_tmux_s)
                     try:
-                        session.attach_session()
-                    except libtmux.exc.LibTmuxException as e:
-                        # there are no attached clients just switch instead.
                         session.switch_client()
-                    self._cache['last_tmux_s'] = self._cur_tmux_s
-                    self._write_cache()
+                    except libtmux.exc.LibTmuxException as e:
+                        session.attach_session()
+                    if self._cur_tmux_s:
+                        self._cache['last_tmux_s'] = self._cur_tmux_s.name
+                        self._write_cache()
                 elif action == 'kill':
                     session.kill_session()
                 else:
@@ -234,11 +240,10 @@ class RFT(object):
         """
         windows = None
         if session_name:
-            session = self._get_session_by_name(session_name=session_name)
+            session = self._get_session_by_name(session_name = session_name)
             windows = session.list_windows()
         else:
-            session = self._get_session_by_name(
-                session_name=self._get_cur_session())
+            session = self._cur_tmux_s
             if session:
                 if global_scope:
                     windows = []
@@ -252,43 +257,42 @@ class RFT(object):
                 "{}:{}:{}".format(w.session.name, w.index, w.name)
                 for w in windows
             ]
-            tmux_wkps = None
-            cur_win = self._get_cur_window()
+            is_tmux_win_visible = False
+            cur_win = self._get_cur_tmux_win()
             if self._wm:
-                tmux_wkps = self._wm.is_tmux_not_in_cur_workspace(
-                    self._cur_tmux_s)
+                self.logger.debug('resolving is_tmux_win_visible...')
+                is_tmux_win_visible = self._wm.is_tmux_win_visible(self._cur_tmux_s)
+                self.logger.debug('is_tmux_win_visible: {}'.format(is_tmux_win_visible))
             try:
-                # if it's not in the cur workspace
-                if tmux_wkps:
-                    sel = windows_str.index(cur_win)
-                else:
+                if is_tmux_win_visible:
                     sel = windows_str.index(self._cache.get('last_tmux_w'))
+                else:
+                    sel = windows_str.index(cur_win)
             except ValueError as e:
                 sel = 0
+
             res, key = self._rofi.select(rofi_msg, windows_str, select=sel)
             if key == 0:
                 win = windows[res]
                 if action == 'switch':
-                    self.logger.debug('selected: {}:{}:{}'.format(
-                        win.session.name, win.index, win.name))
-                    # only switch if workspace it's not in the same workspace
-                    if tmux_wkps:
-                        self._wm.switch_tmux_workspace(win.session.name)
+                    self.logger.debug('selected: {}'.format(windows_str[res]))
+
+                    if self._wm:
+                        self._wm.focus_tmux_window(self._cur_tmux_s)
                     try:
-                        self.logger.debug('tmux switching: {}'.format(
-                            win.session.name))
+                        self.logger.debug('tmux switching: {}'.format(win.session.name))
                         win.session.switch_client()
                         win.select_window()
                     except libtmux.exc.LibTmuxException as e:
                         # there are no attached clients yet
                         # attach if running in the shell
-                        self.logger.debug('tmux attaching: {}'.format(
-                            win.session.name))
+                        self.logger.debug('tmux attaching: {}'.format(win.session.name))
                         win.session.attach_session()
                     self._cache['last_tmux_w'] = cur_win
-                    # also updates last session accordingly
-                    self._cache['last_tmux_s'] = self._cur_tmux_s
-                    self._write_cache()
+                    # also update last session accordingly:
+                    if self._cur_tmux_s:
+                        self._cache['last_tmux_s'] = self._cur_tmux_s.name
+                        self._write_cache()
                 elif action == 'kill':
                     win.kill_window()
                 else:
@@ -319,3 +323,11 @@ class RFT(object):
             rofi_msg='Kill window',
             session_name=session_name,
             global_scope=global_scope)
+
+def _read_dict_from_file(file_loc):
+    try:
+        with open(file_loc, 'r') as f:
+            return json.load(f)
+    except Exception as e:
+        return {}
+

--- a/rft/window_manager.py
+++ b/rft/window_manager.py
@@ -14,15 +14,16 @@ class WindowManager(ABC):
         super(WindowManager, self).__init__()
 
     @abstractmethod
-    def switch_tmux_workspace(self) -> None:
-        """Switches to the workspace where tmux session_name is running
+    def focus_tmux_window(self, session) -> None:
+
+        """Focuses window where given tmux session is running in
 
         """
         pass
 
     @abstractmethod
-    def is_tmux_not_in_cur_workspace(self, session_name) -> bool:
-        """Verifies if tmux is not in the cur workspace
+    def is_tmux_win_visible(self, session) -> bool:
+        """Verifies if window where given tmux session is running in is visible
 
         """
         pass

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     url='http://github.com/viniciusarcanjo/rofi-tmux',
     packages=['rft', 'rft/bin'],
     license='MIT',
-    install_requires=['python-rofi==1.0.1', 'libtmux', 'i3ipc', 'click'],
+    install_requires=['python-rofi==1.0.1', 'libtmux', 'i3ipc>=2.0.1', 'click'],
     entry_points='''
         [console_scripts]
         rft=rft.bin.main:main


### PR DESCRIPTION
    - i3ipc >= v2 incompatibility  - eg workspace.get() no longer works;
    - fix poor multi-monitor support: i3wm._get_cur_workspace() finds visible
      workspace, but multi-head setup has many simultaneously visible workspaces;
      i3ipc has better apis for receiving current, _focused_, workspace;
    - why limit ourselves to i3wm.switch_tmux_workspace()? this is rather poor
      UX if our tmux window is say in a stacked or tabbed container - window could still
      remain hidden; it'd be better to directly focus our tmux window.
    - i3wm._find_tmux_workspace() currently searches for tmux window by session.name,
      which is likely to result in multiple matches, unless our session names are rather
      unique; eg for my session named 'main', I got 3+ matches across multiple workspaces;
    - pass logger (debug) level down to i3wm module;
    - bump required i3ipc ver to >= 2.0.1;
    - _rofi_tmux_window() & _rofi_tmux_session(): for both of them, first
      try to switch to existing client via session.switch_client();
      if that fails, _only_ then try attaching with session.attach_session();
    - introduce new config items:
      - tmux_title_rgx: regex to seek tmux window by - this allows us to
        more accurately trace down the window containing tmux window; note it supports
        optional placeholders {session} & {window};
      - ignored_sessions: array of tmux session names that should be ignored
        by rtf;

@viniarck  - could you confirm switch vs attach logic described above is what we want? It differs from current behavior, but makes sense to me - first we try to switch to existing client; if that fails, then try attaching. Don't see why we should try attaching first in `_rofi_tmux_session()`.